### PR TITLE
Fix the bug of wrong X axis when there are some lines with negative Y values

### DIFF
--- a/project/digitalizer-core/src/main/java/com/fredericboisguerin/pdf/infrastructure/wrapper/CoordComparator.java
+++ b/project/digitalizer-core/src/main/java/com/fredericboisguerin/pdf/infrastructure/wrapper/CoordComparator.java
@@ -15,9 +15,9 @@ public class CoordComparator implements Comparator<Float> {
     }
 
     private boolean areEqual(Float c1, Float c2) {
-        float dist = Math.abs(c2 - c1);
+        float dist = c2 - c1;
         float minAbs = Math.min(c1, c2);
-        float ratio = dist / minAbs;
+        float ratio = Math.abs(dist / minAbs);
         return Float.compare(ratio, RATIO_TOLERANCE) < 0;
     }
 

--- a/project/digitalizer-core/src/test/java/com/fredericboisguerin/pdf/infrastructure/wrapper/CoordComparatorTest.java
+++ b/project/digitalizer-core/src/test/java/com/fredericboisguerin/pdf/infrastructure/wrapper/CoordComparatorTest.java
@@ -1,0 +1,41 @@
+package com.fredericboisguerin.pdf.infrastructure.wrapper;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CoordComparatorTest {
+
+    private static final int EQUAL = 0;
+    private static final int GREATER_THAN = 1;
+
+    @Test
+    public void should_return_equal_constant_when_values_are_stricly_equal() throws Exception {
+        int returnedValue = new CoordComparator().compare(1.23456f, 1.23456f);
+        assertThat(returnedValue).isEqualTo(EQUAL);
+    }
+
+    @Test
+    public void should_return_equal_constant_when_negative_values_are_stricly_equal() throws Exception {
+        int returnedValue = new CoordComparator().compare(-1.23456f, -1.23456f);
+        assertThat(returnedValue).isEqualTo(EQUAL);
+    }
+
+    @Test
+    public void should_return_equal_constant_when_negative_values_are_close_by_ten_ppm() throws Exception {
+        int returnedValue = new CoordComparator().compare(-1000f, -1000.01f);
+        assertThat(returnedValue).isEqualTo(EQUAL);
+    }
+
+    @Test
+    public void should_return_greaterThan_constant_when_negative_values_are_close_by_one_percent() throws Exception {
+        int returnedValue = new CoordComparator().compare(-1000f, -1010f);
+        assertThat(returnedValue).isEqualTo(GREATER_THAN);
+    }
+
+    @Test
+    public void should_return_greaterThan_constant_when_negative_values_are_close_by_one_thousand_ppm() throws Exception {
+        int returnedValue = new CoordComparator().compare(-1000f, -1001f);
+        assertThat(returnedValue).isEqualTo(GREATER_THAN);
+    }
+}


### PR DESCRIPTION
When the tool try to find the horizontal lines, it can occurs that lines with negative Y values are considered horizontal even if they are not.

It was due to an issue in equal check with negative values